### PR TITLE
recursively fetch comments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,8 @@ app({
           return Promise.all(d.kids.map(a.fetchItem))
             .then(kids => Promise.all(kids.map(fetchComments)))
         }
+
+        return Promise.resolve()
       }
 
       return fetchComments(d)


### PR DESCRIPTION
Basically, we need a way to fetch all comments for all descendants of an item.

I've made this work by changing `a.fetchItemComments` to call a recursive function that returns a promise. This recursive function checks if an item exists and has kids. If it does it will cache it in an object `const comments = {}` that lives in the scope of `a.fetchItemComments`. This promise chain will finish when all descendants have been found. We then return a new promise that will resolve `const comments` . From there we can set the new state of `state.comments`. 

I also added an `update` event that logs the number of comments. When `a.setComments` is called it will change the state and `update` event will be called logging the # of objects and the object itself. This is just for debugging so you can see this happening in real time.